### PR TITLE
feat: Interactive SSH auth support and ShellService refactor

### DIFF
--- a/agent-core/lib/src/services/shell_service.dart
+++ b/agent-core/lib/src/services/shell_service.dart
@@ -588,7 +588,7 @@ ${envExports}DECAMP_SECRETS
 
   /// Handle SSH keyboard-interactive requests
   Future<List<String>> _handleUserInfoRequest(
-    dynamic request, {
+    SSHUserInfoRequest request, {
     String? passwordFallback,
   }) async {
     final prompts = request.prompts;

--- a/agent-core/lib/src/services/shell_service.dart
+++ b/agent-core/lib/src/services/shell_service.dart
@@ -5,6 +5,8 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
+// ignore: implementation_imports
+import 'package:dartssh2/src/ssh_userauth.dart';
 import '../models/ssh_settings.dart';
 import 'keychain_service.dart';
 
@@ -41,9 +43,12 @@ class ShellService {
       );
 
       // Get credentials from inline or keychain
-      final password = await _getCredential(inlinePassword, sshSettings.passwordSecretId);
-      final privateKey = await _getCredential(inlinePrivateKey, sshSettings.privateKeySecretId);
-      final passphrase = await _getCredential(inlinePassphrase, sshSettings.passphraseSecretId);
+      final password =
+          await _getCredential(inlinePassword, sshSettings.passwordSecretId);
+      final privateKey = await _getCredential(
+          inlinePrivateKey, sshSettings.privateKeySecretId);
+      final passphrase = await _getCredential(
+          inlinePassphrase, sshSettings.passphraseSecretId);
 
       // Create SSH socket
       final socket = await SSHSocket.connect(
@@ -62,7 +67,8 @@ class ShellService {
           socket,
           username: sshSettings.username,
           onPasswordRequest: () => password,
-          onUserInfoRequest: (request) => _handleUserInfoRequest(request, passwordFallback: password),
+          onUserInfoRequest: (request) =>
+              _handleUserInfoRequest(request, passwordFallback: password),
         );
       } else {
         // Private key authentication
@@ -628,7 +634,8 @@ ${envExports}DECAMP_SECRETS
   /// Returns inline value if provided, otherwise fetches from keychain
   Future<String?> _getCredential(String? inlineValue, String? secretId) async {
     if (inlineValue != null) return inlineValue;
-    if (_keychain == null || _projectId == null || secretId == null) return null;
+    if (_keychain == null || _projectId == null || secretId == null)
+      return null;
     return await _keychain.getProjectSecret(_projectId, secretId);
   }
 }

--- a/agent-core/lib/src/services/shell_service.dart
+++ b/agent-core/lib/src/services/shell_service.dart
@@ -8,6 +8,9 @@ import 'package:dartssh2/dartssh2.dart';
 import '../models/ssh_settings.dart';
 import 'keychain_service.dart';
 
+/// Callback for interactive user prompts (e.g. 2FA, password)
+typedef UserPromptCallback = Future<String> Function(String prompt, bool echo);
+
 /// Service for executing shell commands via SSH
 class ShellService {
   SSHClient? _client;
@@ -15,42 +18,32 @@ class ShellService {
   final KeychainService? _keychain;
   final String? _projectId;
 
+  /// Callback for handling interactive prompts from the SSH server
+  UserPromptCallback? onUserPrompt;
+
   ShellService(this._sshSettings, this._keychain, this._projectId);
 
   /// Connect to SSH server using the provided settings
   /// Returns true if connection successful, false otherwise
-  Future<bool> connect(SshSettings sshSettings) async {
+  ///
+  /// Optional inline credentials can be provided for testing purposes.
+  /// If provided, they override credentials from the keychain.
+  Future<bool> connect(
+    SshSettings sshSettings, {
+    String? inlinePassword,
+    String? inlinePrivateKey,
+    String? inlinePassphrase,
+  }) async {
     try {
       developer.log(
         'Connecting to SSH: ${sshSettings.username}@${sshSettings.host}:${sshSettings.port}',
         name: 'ShellService',
       );
 
-      // Get credentials from secrets
-      String? password;
-      String? privateKey;
-      String? passphrase;
-
-      if (_keychain != null && _projectId != null) {
-        if (sshSettings.passwordSecretId != null) {
-          password = await _keychain.getProjectSecret(
-            _projectId,
-            sshSettings.passwordSecretId!,
-          );
-        }
-        if (sshSettings.privateKeySecretId != null) {
-          privateKey = await _keychain.getProjectSecret(
-            _projectId,
-            sshSettings.privateKeySecretId!,
-          );
-        }
-        if (sshSettings.passphraseSecretId != null) {
-          passphrase = await _keychain.getProjectSecret(
-            _projectId,
-            sshSettings.passphraseSecretId!,
-          );
-        }
-      }
+      // Get credentials from inline or keychain
+      final password = await _getCredential(inlinePassword, sshSettings.passwordSecretId);
+      final privateKey = await _getCredential(inlinePrivateKey, sshSettings.privateKeySecretId);
+      final passphrase = await _getCredential(inlinePassphrase, sshSettings.passphraseSecretId);
 
       // Create SSH socket
       final socket = await SSHSocket.connect(
@@ -69,6 +62,7 @@ class ShellService {
           socket,
           username: sshSettings.username,
           onPasswordRequest: () => password,
+          onUserInfoRequest: (request) => _handleUserInfoRequest(request, passwordFallback: password),
         );
       } else {
         // Private key authentication
@@ -80,8 +74,12 @@ class ShellService {
           socket,
           username: sshSettings.username,
           identities: [...SSHKeyPair.fromPem(privateKey, passphrase)],
+          onUserInfoRequest: (request) => _handleUserInfoRequest(request),
         );
       }
+
+      // Wait for authentication to complete
+      await _client!.authenticated;
 
       developer.log('SSH connection established', name: 'ShellService');
       return true;
@@ -588,6 +586,33 @@ ${envExports}DECAMP_SECRETS
     return RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(name);
   }
 
+  /// Handle SSH keyboard-interactive requests
+  Future<List<String>> _handleUserInfoRequest(
+    dynamic request, {
+    String? passwordFallback,
+  }) async {
+    final prompts = request.prompts;
+    if (onUserPrompt == null) {
+      // If no callback provided, try to use the stored password for the first prompt
+      // This is a fallback for servers that use keyboard-interactive for simple password auth
+      if (passwordFallback != null && prompts.isNotEmpty) {
+        final promptText = prompts.first.promptText;
+        if (promptText.toLowerCase().contains('password') ||
+            promptText.trim().endsWith(':')) {
+          return [passwordFallback];
+        }
+      }
+      return [];
+    }
+
+    final answers = <String>[];
+    for (var prompt in prompts) {
+      final answer = await onUserPrompt!(prompt.promptText, prompt.echo);
+      answers.add(answer);
+    }
+    return answers;
+  }
+
   /// Redact secrets from output text
   String _redactSecrets(String text, List<String> secrets) {
     var redacted = text;
@@ -597,5 +622,13 @@ ${envExports}DECAMP_SECRETS
       }
     }
     return redacted;
+  }
+
+  /// Get credential from inline value or keychain
+  /// Returns inline value if provided, otherwise fetches from keychain
+  Future<String?> _getCredential(String? inlineValue, String? secretId) async {
+    if (inlineValue != null) return inlineValue;
+    if (_keychain == null || _projectId == null || secretId == null) return null;
+    return await _keychain.getProjectSecret(_projectId, secretId);
   }
 }

--- a/decamp-app/INTERACTIVE_SSH_DESIGN.md
+++ b/decamp-app/INTERACTIVE_SSH_DESIGN.md
@@ -1,0 +1,64 @@
+# Interactive SSH Design & Implementation
+
+## Overview
+This document details the implementation of interactive SSH support (keyboard-interactive authentication) in the Decamp application. This feature enables the application to handle 2FA/OTP prompts and other interactive challenges from SSH servers.
+
+## Architecture
+
+The implementation spans two main packages: `agent-core` (logic) and `decamp-app` (UI).
+
+### 1. Agent Core (`agent-core`)
+
+**File:** `lib/src/services/shell_service.dart`
+
+The `ShellService` class was modified to support the `keyboard-interactive` authentication method provided by the `dartssh2` package.
+
+*   **Callback Definition:** A new typedef `UserPromptCallback` was defined to abstract the UI interaction.
+    ```dart
+    typedef UserPromptCallback = Future<String> Function(String prompt, bool echo);
+    ```
+*   **Service Property:** Added `UserPromptCallback? onUserPrompt` to `ShellService`.
+*   **Connection Logic:** Updated the `connect` method to pass a handler to the `SSHClient` constructor's `onUserInfoRequest` parameter.
+    *   **Handler Logic:**
+        1.  Checks if `onUserPrompt` is set.
+        2.  If NOT set (headless mode), it attempts a fallback: if the prompt looks like a password request, it sends the stored password.
+        3.  If set (interactive mode), it iterates through the prompts received from the server.
+        4.  For each prompt, it awaits the `onUserPrompt` callback, passing the `promptText` and `echo` flag.
+        5.  Collects and returns the user's responses to the SSH client.
+
+### 2. Decamp App (`decamp-app`)
+
+**File:** `lib/pages/chat_session.dart`
+
+The UI layer was updated to provide the concrete implementation of the user prompt callback.
+
+*   **Callback Implementation:** Added `_handleSshPrompt` method to `ChatSession`.
+    *   **UI:** Uses `showDialog` to present an `AlertDialog`.
+    *   **Input:** Contains a `TextField` that respects the `echo` flag (obscures text if `echo` is false).
+    *   **Flow:** Pauses execution until the user submits the dialog. Returns the entered text.
+*   **Dependency Injection:** In the `build` method, the `ShellService` is watched via Riverpod. The `onUserPrompt` property is assigned to `_handleSshPrompt`.
+    ```dart
+    if (currentProject != null) {
+      final shellService = ref.watch(shellServiceProvider(currentProject.id));
+      shellService.onUserPrompt = _handleSshPrompt;
+    }
+    ```
+
+## Authentication Flow
+
+1.  **Initiation:** The app attempts to execute a command or connect via `ShellService`.
+2.  **Handshake:** `dartssh2` performs the SSH handshake.
+3.  **Auth Request:** The server requests `keyboard-interactive` authentication (e.g., for 2FA).
+4.  **Client Handler:** `dartssh2` calls the `onUserInfoRequest` handler defined in `ShellService`.
+5.  **UI Callback:** `ShellService` calls `onUserPrompt`.
+6.  **User Interaction:**
+    *   `ChatSession` shows a dialog with the server's prompt (e.g., "Verification code:").
+    *   User enters the code and presses "Submit".
+7.  **Response:** The code is returned to `ShellService`, then to `dartssh2`, and finally sent to the server.
+8.  **Completion:** If valid, the connection is established.
+
+## Key Decisions
+
+*   **Callback Injection:** We inject the UI callback into the service rather than coupling the service to the UI library. This keeps `agent-core` pure Dart and testable.
+*   **Fallback Logic:** We retained a fallback for headless environments where a simple password prompt might be sent via keyboard-interactive mode, ensuring backward compatibility.
+*   **Riverpod Integration:** We leverage Riverpod's `ref.watch` to keep the service and UI in sync, ensuring the callback is always attached to the active service instance.

--- a/decamp-app/lib/components/ssh_prompt_dialog.dart
+++ b/decamp-app/lib/components/ssh_prompt_dialog.dart
@@ -9,45 +9,69 @@ Future<String> showSshPrompt(
 ) async {
   if (!context.mounted) return '';
 
-  final controller = TextEditingController();
   return await showDialog<String>(
         context: context,
         barrierDismissible: false,
-        builder: (context) {
-          return AlertDialog(
-            title: const Text('SSH Authentication Required'),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(prompt),
-                const SizedBox(height: 16),
-                TextField(
-                  controller: controller,
-                  obscureText: !echo,
-                  autofocus: true,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'Enter response',
-                  ),
-                  onSubmitted: (value) {
-                    Navigator.of(context).pop(value);
-                  },
-                ),
-              ],
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(''),
-                child: const Text('Cancel'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(controller.text),
-                child: const Text('Submit'),
-              ),
-            ],
-          );
-        },
+        builder: (context) => _SshPromptDialog(prompt: prompt, echo: echo),
       ) ??
       '';
+}
+
+class _SshPromptDialog extends StatefulWidget {
+  final String prompt;
+  final bool echo;
+
+  const _SshPromptDialog({required this.prompt, required this.echo});
+
+  @override
+  State<_SshPromptDialog> createState() => _SshPromptDialogState();
+}
+
+class _SshPromptDialogState extends State<_SshPromptDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit([String? value]) {
+    Navigator.of(context).pop(value ?? _controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('SSH Authentication Required'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(widget.prompt),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _controller,
+            obscureText: !widget.echo,
+            autofocus: true,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'Enter response',
+            ),
+            onSubmitted: _submit,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(onPressed: () => _submit(''), child: const Text('Cancel')),
+        TextButton(onPressed: _submit, child: const Text('Submit')),
+      ],
+    );
+  }
 }

--- a/decamp-app/lib/components/ssh_prompt_dialog.dart
+++ b/decamp-app/lib/components/ssh_prompt_dialog.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+/// Show SSH interactive prompt dialog
+/// Returns the user's response or empty string if cancelled
+Future<String> showSshPrompt(
+  BuildContext context,
+  String prompt,
+  bool echo,
+) async {
+  if (!context.mounted) return '';
+
+  final controller = TextEditingController();
+  return await showDialog<String>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('SSH Authentication Required'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(prompt),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: controller,
+                  obscureText: !echo,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'Enter response',
+                  ),
+                  onSubmitted: (value) {
+                    Navigator.of(context).pop(value);
+                  },
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(''),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(controller.text),
+                child: const Text('Submit'),
+              ),
+            ],
+          );
+        },
+      ) ??
+      '';
+}

--- a/decamp-app/lib/components/ssh_settings_dialog.dart
+++ b/decamp-app/lib/components/ssh_settings_dialog.dart
@@ -768,7 +768,7 @@ class _SshSettingsDialogFormState
       );
 
       if (!connected) {
-        throw Exception('Connection failed');
+        throw Exception('Connection failed. Please check your settings and credentials. More details may be available in the developer logs.');
       }
 
       // Disconnect immediately - authentication success is sufficient

--- a/decamp-app/lib/components/ssh_settings_dialog.dart
+++ b/decamp-app/lib/components/ssh_settings_dialog.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:dartssh2/dartssh2.dart';
 import 'package:agent_core/agent_core.dart';
+import 'ssh_prompt_dialog.dart';
 import '../providers/ssh_settings_provider.dart';
 
 /// Reusable dialog for configuring SSH/Remote Shell settings
@@ -747,31 +747,38 @@ class _SshSettingsDialogFormState
         enabled: true,
       );
 
-      // Attempt to connect with inline credentials
-      bool connected = false;
+      // Create ShellService instance with inline credentials
+      final shellService = ShellService(null, null, null);
+      shellService.onUserPrompt = (prompt, echo) => 
+          showSshPrompt(context, prompt, echo);
 
-      if (_authMethod == SshAuthMethod.password) {
-        connected = await _testConnectionWithPassword(
-          testSettings,
-          _passwordController.text,
-        );
-      } else {
-        connected = await _testConnectionWithPrivateKey(
-          testSettings,
-          _privateKeyController.text,
-          _passphraseController.text.isEmpty
-              ? null
-              : _passphraseController.text,
-        );
+      // Connect with inline credentials
+      final connected = await shellService.connect(
+        testSettings,
+        inlinePassword: _authMethod == SshAuthMethod.password
+            ? _passwordController.text
+            : null,
+        inlinePrivateKey: _authMethod == SshAuthMethod.privateKey
+            ? _privateKeyController.text
+            : null,
+        inlinePassphrase: _authMethod == SshAuthMethod.privateKey &&
+                _passphraseController.text.isNotEmpty
+            ? _passphraseController.text
+            : null,
+      );
+
+      if (!connected) {
+        throw Exception('Connection failed');
       }
+
+      // Disconnect immediately - authentication success is sufficient
+      shellService.disconnect();
 
       if (mounted) {
         setState(() {
           _isTestingConnection = false;
-          _testResultSuccess = connected;
-          _testResultMessage = connected
-              ? 'Connection successful!'
-              : 'Connection failed. Please check your settings.';
+          _testResultSuccess = true;
+          _testResultMessage = 'Connection successful!';
         });
         _scrollToBottom();
       }
@@ -798,61 +805,6 @@ class _SshSettingsDialogFormState
         );
       }
     });
-  }
-
-  Future<bool> _testConnectionWithPassword(
-    SshSettings settings,
-    String password,
-  ) async {
-    try {
-      final socket = await SSHSocket.connect(
-        settings.host,
-        settings.port,
-        timeout: const Duration(seconds: 30),
-      );
-
-      final client = SSHClient(
-        socket,
-        username: settings.username,
-        onPasswordRequest: () => password,
-      );
-
-      // Test with a simple command
-      await client.run('echo test');
-      client.close();
-
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  Future<bool> _testConnectionWithPrivateKey(
-    SshSettings settings,
-    String privateKey,
-    String? passphrase,
-  ) async {
-    try {
-      final socket = await SSHSocket.connect(
-        settings.host,
-        settings.port,
-        timeout: const Duration(seconds: 30),
-      );
-
-      final client = SSHClient(
-        socket,
-        username: settings.username,
-        identities: [...SSHKeyPair.fromPem(privateKey, passphrase)],
-      );
-
-      // Test with a simple command
-      await client.run('echo test');
-      client.close();
-
-      return true;
-    } catch (e) {
-      return false;
-    }
   }
 
   void _save() {

--- a/decamp-app/lib/pages/chat_session.dart
+++ b/decamp-app/lib/pages/chat_session.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:decamp/providers/shell_service_provider.dart';
+import 'package:decamp/components/ssh_prompt_dialog.dart';
 import 'package:decamp/components/main_drawer.dart';
 import 'package:decamp/components/multi_command_approval_overlay.dart';
 import 'package:decamp/components/execution_progress_overlay.dart';
@@ -235,6 +237,11 @@ class _ChatSessionState extends ConsumerState<ChatSession> {
     );
   }
 
+  /// Handle SSH interactive prompts (e.g. 2FA, password)
+  Future<String> _handleSshPrompt(String prompt, bool echo) async {
+    return showSshPrompt(context, prompt, echo);
+  }
+
   @override
   Widget build(BuildContext context) {
     // Activate auto-session selection
@@ -243,6 +250,12 @@ class _ChatSessionState extends ConsumerState<ChatSession> {
     // Watch current state
     final currentProject = ref.watch(currentProjectProvider);
     final currentSessionId = ref.watch(currentSessionIdProvider);
+
+    // Inject SSH prompt callback
+    if (currentProject != null) {
+      final shellService = ref.watch(shellServiceProvider(currentProject.id));
+      shellService.onUserPrompt = _handleSshPrompt;
+    }
 
     // Unfocus when session or project changes
     ref.listen(currentSessionIdProvider, (previous, next) {

--- a/decamp-app/lib/pages/chat_session.dart
+++ b/decamp-app/lib/pages/chat_session.dart
@@ -253,8 +253,11 @@ class _ChatSessionState extends ConsumerState<ChatSession> {
 
     // Inject SSH prompt callback
     if (currentProject != null) {
-      final shellService = ref.watch(shellServiceProvider(currentProject.id));
-      shellService.onUserPrompt = _handleSshPrompt;
+      final shellServiceProv = shellServiceProvider(currentProject.id);
+      ref.listen(shellServiceProv, (_, shellService) {
+        shellService.onUserPrompt = _handleSshPrompt;
+      });
+      ref.read(shellServiceProv).onUserPrompt = _handleSshPrompt;
     }
 
     // Unfocus when session or project changes


### PR DESCRIPTION
~50 new lines of code (if you ignore the *.md file), mostly going to `ssh_prompt_dialog.dart`

Few things:
- being able to handle interactive ssh requests (2FA, or if the password for some reason requires interactive), which includes a small UI component
- refactored some duplicate code for testing connection between `shell_service.dart` and `ssh_settings_dialog.dart`. now connections are always handled or tested in the former

