### PR TITLE
Add CrdtFlowAdapter and ensure message order is guaranteed (fixes rac…

### DIFF
--- a/agent-core/lib/agent_core.dart
+++ b/agent-core/lib/agent_core.dart
@@ -21,6 +21,7 @@ export 'src/utils/id_generator.dart';
 export 'src/utils/template_processor.dart';
 export 'src/utils/tool_result_formatter.dart';
 export 'src/utils/multiplexed_websocket_channel.dart';
+export 'src/utils/crdt_flow_adapter.dart';
 
 // Secrets Storage
 export 'src/secrets_storage/secure_storage.dart';

--- a/agent-core/lib/src/controllers/chat_controller.dart
+++ b/agent-core/lib/src/controllers/chat_controller.dart
@@ -447,7 +447,10 @@ class ChatController extends StateNotifier<ChatState> {
             message: final errorMsg,
             messageId: final messageId
           ):
-          final errorMessage = 'Sorry, I encountered an error+: $errorMsg';
+          if (mounted) {
+            state = state.copyWith(isLoading: false, error: errorMsg);
+          }
+          final errorMessage = 'Sorry, I encountered an error: $errorMsg';
           final redactedError = await _secretRedactor.redact(errorMessage);
           final aiUserName = await _getAiUserName();
           await _messageDao.insertMessageWithId(
@@ -459,9 +462,6 @@ class ChatController extends StateNotifier<ChatState> {
             isVisibleToLlm: false,
           );
           await _sessionDao.touchSession(sessionId);
-          if (mounted) {
-            state = state.copyWith(isLoading: false, error: errorMsg);
-          }
           return;
       }
 

--- a/agent-core/lib/src/database/daos/project_dao.dart
+++ b/agent-core/lib/src/database/daos/project_dao.dart
@@ -1,6 +1,5 @@
 import 'package:drift/drift.dart';
 import 'package:agent_core/agent_core.dart';
-import '../entities/listable_entity.dart';
 
 part 'project_dao.g.dart';
 

--- a/agent-core/lib/src/database/daos/session_dao.dart
+++ b/agent-core/lib/src/database/daos/session_dao.dart
@@ -1,6 +1,5 @@
 import 'package:drift/drift.dart';
 import 'package:agent_core/agent_core.dart';
-import '../entities/listable_entity.dart';
 
 part 'session_dao.g.dart';
 

--- a/agent-core/lib/src/services/remote_agent_service.dart
+++ b/agent-core/lib/src/services/remote_agent_service.dart
@@ -21,56 +21,50 @@ Future<AgentLoopResult> runRemoteAgentLoop({
   final completer = Completer<AgentLoopResult>();
 
   // Listen for messages on the custom channel
-  final subscription = channel.onCustomMessage.listen(
-    (data) async {
-      try {
-        final type = data['type'] as String;
+  Future<void> handleMessage(Map<String, dynamic> data) async {
+    try {
+      final type = data['type'] as String;
 
-        if (type == 'request_approval') {
-          final toolsJson =
-              (data['tools'] as List).cast<Map<String, dynamic>>();
-          final pendingCalls = toolsJson
-              .map((j) => PendingToolCall(
-                  id: j['id'],
-                  name: j['name'],
-                  arguments: j['arguments'],
-                  originalToolCall: ToolCall(
-                      id: j['id'],
-                      callType: 'function',
-                      function: FunctionCall(
-                          name: j['name'],
-                          arguments: jsonEncode(j['arguments'])))))
-              .toList();
+      if (type == 'request_approval') {
+        final toolsJson = (data['tools'] as List).cast<Map<String, dynamic>>();
+        final pendingCalls = toolsJson
+            .map((j) => PendingToolCall(
+                id: j['id'],
+                name: j['name'],
+                arguments: j['arguments'],
+                originalToolCall: ToolCall(
+                    id: j['id'],
+                    callType: 'function',
+                    function: FunctionCall(
+                        name: j['name'],
+                        arguments: jsonEncode(j['arguments'])))))
+            .toList();
 
-          final approved = await requestApproval(pendingCalls);
+        final approved = await requestApproval(pendingCalls);
 
-          channel.sendCustomMessage({
-            'type': 'approval_response',
-            'approvedIds': approved?.map((c) => c.id).toList()
-          });
-        } else if (type == 'complete') {
-          if (!completer.isCompleted) {
-            completer.complete(const AgentLoopCompleted());
-          }
-        } else if (type == 'error') {
-          if (!completer.isCompleted) {
-            completer.complete(
-                AgentLoopError(data['message'], messageId: data['message_id']));
-          }
-        }
-      } catch (e) {
-        _log.warning('Error handling remote message: $e');
+        channel.sendCustomMessage({
+          'type': 'approval_response',
+          'approvedIds': approved?.map((c) => c.id).toList()
+        });
+      } else if (type == 'complete') {
         if (!completer.isCompleted) {
-          completer.complete(AgentLoopError(e.toString()));
+          completer.complete(const AgentLoopCompleted());
+        }
+      } else if (type == 'error') {
+        if (!completer.isCompleted) {
+          completer.complete(
+              AgentLoopError(data['message'], messageId: data['message_id']));
         }
       }
-    },
-    onError: (e) {
+    } catch (e) {
+      _log.warning('Error handling remote message: $e');
       if (!completer.isCompleted) {
         completer.complete(AgentLoopError(e.toString()));
       }
-    },
-  );
+    }
+  }
+
+  channel.registerCustomHandler(handleMessage);
 
   // Start chat
   channel.sendCustomMessage({
@@ -83,6 +77,6 @@ Future<AgentLoopResult> runRemoteAgentLoop({
   try {
     return await completer.future;
   } finally {
-    await subscription.cancel();
+    channel.unregisterCustomHandler(handleMessage);
   }
 }

--- a/agent-core/lib/src/utils/crdt_flow_adapter.dart
+++ b/agent-core/lib/src/utils/crdt_flow_adapter.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'package:crdt/crdt.dart';
+
+/// Adapts a [Crdt] to track when merge operations are in progress.
+/// This allows synchronizing external events with the CRDT merge stream.
+class CrdtFlowAdapter implements Crdt {
+  final Crdt _inner;
+  Future<void> _lastMerge = Future.value();
+
+  CrdtFlowAdapter(this._inner);
+
+  /// Returns a future that completes when the last merge operation finishes.
+  Future<void> get onIdle => _lastMerge;
+
+  @override
+  Hlc get canonicalTime => _inner.canonicalTime;
+
+  @override
+  set canonicalTime(Hlc value) {
+    // Protected member, cannot delegate.
+    // Should not be called by consumers.
+    throw UnimplementedError();
+  }
+
+  @override
+  String get nodeId => _inner.nodeId;
+
+  @override
+  Stream<({Hlc hlc, Iterable<String> tables})> get onTablesChanged =>
+      _inner.onTablesChanged;
+
+  @override
+  FutureOr<Hlc> getLastModified({String? onlyNodeId, String? exceptNodeId}) =>
+      _inner.getLastModified(
+          onlyNodeId: onlyNodeId, exceptNodeId: exceptNodeId);
+
+  @override
+  FutureOr<CrdtChangeset> getChangeset({
+    Iterable<String>? onlyTables,
+    String? onlyNodeId,
+    String? exceptNodeId,
+    Hlc? modifiedOn,
+    Hlc? modifiedAfter,
+  }) =>
+      _inner.getChangeset(
+        onlyTables: onlyTables,
+        onlyNodeId: onlyNodeId,
+        exceptNodeId: exceptNodeId,
+        modifiedOn: modifiedOn,
+        modifiedAfter: modifiedAfter,
+      );
+
+  @override
+  FutureOr<void> merge(CrdtChangeset changeset) {
+    final result = _inner.merge(changeset);
+    if (result is Future) {
+      final future = result as Future<void>;
+      _lastMerge = future.catchError((_) {});
+      return future;
+    }
+  }
+
+  @override
+  Hlc validateChangeset(CrdtChangeset changeset) {
+    // Protected member, cannot delegate.
+    // Should not be called by consumers.
+    throw UnimplementedError();
+  }
+
+  @override
+  void onDatasetChanged(Iterable<String> affectedTables, Hlc hlc) {
+    // Protected member, cannot delegate.
+    // Should not be called by consumers.
+    throw UnimplementedError();
+  }
+}

--- a/agent-core/lib/src/utils/multiplexed_websocket_channel.dart
+++ b/agent-core/lib/src/utils/multiplexed_websocket_channel.dart
@@ -23,40 +23,54 @@ class MultiplexedWebSocketChannel extends StreamChannelMixin
 
   MultiplexedWebSocketChannel(this._inner, {this.awaitSync}) {
     _inner.stream.listen((data) {
-      // Chain processing to ensure order
-      _pending = _pending.then((_) async {
-        if (data is String && data.startsWith(_customPrefix)) {
-          // If it's a custom message, wait for any pending sync operations
-          if (awaitSync != null) {
-            try {
-              await awaitSync!();
-            } catch (e) {
-              _log.warning('Error waiting for sync: $e');
-            }
-          }
-
-          try {
-            final payload = data.substring(_customPrefix.length);
-            final decoded = jsonDecode(payload);
-            if (decoded is Map<String, dynamic>) {
-              // Wait for registered handlers to complete
-              if (_customHandlers.isNotEmpty) {
-                await Future.wait(_customHandlers.map((h) => h(decoded)));
+      // Chain processing to ensure order.
+      // We use catchError to ensure the chain continues even if a previous task failed.
+      _pending = _pending.catchError((_) {}).then((_) async {
+        try {
+          if (data is String && data.startsWith(_customPrefix)) {
+            // If it's a custom message, wait for any pending sync operations
+            if (awaitSync != null) {
+              try {
+                await awaitSync!();
+              } catch (e) {
+                _log.warning('Error waiting for sync: $e');
               }
-              _customMessageController.add(decoded);
-            } else {
-              _log.warning('Custom message payload is not a Map: $decoded');
             }
-          } catch (e, stackTrace) {
-            // Ignore malformed custom messages
-            _log.warning(
-              'Error parsing custom message: $e',
-              e,
-              stackTrace,
-            );
+
+            try {
+              final payload = data.substring(_customPrefix.length);
+              final decoded = jsonDecode(payload);
+              if (decoded is Map<String, dynamic>) {
+                // Wait for registered handlers to complete
+                if (_customHandlers.isNotEmpty) {
+                  await Future.wait(_customHandlers.map((h) async {
+                    try {
+                      await h(decoded);
+                    } catch (e, st) {
+                      _log.warning('Error in custom message handler', e, st);
+                    }
+                  }));
+                }
+                _customMessageController.add(decoded);
+              } else {
+                _log.warning('Custom message payload is not a Map: $decoded');
+              }
+            } catch (e, stackTrace) {
+              // Ignore malformed custom messages
+              _log.warning(
+                'Error parsing custom message: $e',
+                e,
+                stackTrace,
+              );
+            }
+          } else {
+            if (!_inboundController.isClosed) {
+              _inboundController.add(data);
+            }
           }
-        } else {
-          _inboundController.add(data);
+        } catch (e, stackTrace) {
+          _log.severe(
+              'Error processing message in multiplexed channel', e, stackTrace);
         }
       });
     }, onError: (error, stackTrace) {

--- a/agent-core/lib/src/utils/multiplexed_websocket_channel.dart
+++ b/agent-core/lib/src/utils/multiplexed_websocket_channel.dart
@@ -19,6 +19,7 @@ class MultiplexedWebSocketChannel extends StreamChannelMixin
 
   final Future<void> Function()? awaitSync;
   Future<void> _pending = Future.value();
+  final List<Future<void> Function(Map<String, dynamic>)> _customHandlers = [];
 
   MultiplexedWebSocketChannel(this._inner, {this.awaitSync}) {
     _inner.stream.listen((data) {
@@ -38,6 +39,10 @@ class MultiplexedWebSocketChannel extends StreamChannelMixin
             final payload = data.substring(_customPrefix.length);
             final decoded = jsonDecode(payload);
             if (decoded is Map<String, dynamic>) {
+              // Wait for registered handlers to complete
+              if (_customHandlers.isNotEmpty) {
+                await Future.wait(_customHandlers.map((h) => h(decoded)));
+              }
               _customMessageController.add(decoded);
             } else {
               _log.warning('Custom message payload is not a Map: $decoded');
@@ -75,6 +80,16 @@ class MultiplexedWebSocketChannel extends StreamChannelMixin
 
   Stream<Map<String, dynamic>> get onCustomMessage =>
       _customMessageController.stream;
+
+  void registerCustomHandler(
+      Future<void> Function(Map<String, dynamic>) handler) {
+    _customHandlers.add(handler);
+  }
+
+  void unregisterCustomHandler(
+      Future<void> Function(Map<String, dynamic>) handler) {
+    _customHandlers.remove(handler);
+  }
 
   @override
   String? get protocol => _inner.protocol;

--- a/agent-core/lib/src/utils/multiplexed_websocket_channel.dart
+++ b/agent-core/lib/src/utils/multiplexed_websocket_channel.dart
@@ -9,7 +9,7 @@ class MultiplexedWebSocketChannel extends StreamChannelMixin
   static final _log = Logger('MultiplexedWebSocketChannel');
 
   final WebSocketChannel _inner;
-  final StreamController _inboundController = StreamController();
+  final StreamController _inboundController = StreamController(sync: true);
   final StreamController<Map<String, dynamic>> _customMessageController =
       StreamController.broadcast();
   // Use Unit Separator (ASCII 31) as a prefix to avoid collisions with JSON
@@ -17,28 +17,43 @@ class MultiplexedWebSocketChannel extends StreamChannelMixin
 
   late final WebSocketSink _sink = _MultiplexedSink(_inner.sink);
 
-  MultiplexedWebSocketChannel(this._inner) {
+  final Future<void> Function()? awaitSync;
+  Future<void> _pending = Future.value();
+
+  MultiplexedWebSocketChannel(this._inner, {this.awaitSync}) {
     _inner.stream.listen((data) {
-      if (data is String && data.startsWith(_customPrefix)) {
-        try {
-          final payload = data.substring(_customPrefix.length);
-          final decoded = jsonDecode(payload);
-          if (decoded is Map<String, dynamic>) {
-            _customMessageController.add(decoded);
-          } else {
-            _log.warning('Custom message payload is not a Map: $decoded');
+      // Chain processing to ensure order
+      _pending = _pending.then((_) async {
+        if (data is String && data.startsWith(_customPrefix)) {
+          // If it's a custom message, wait for any pending sync operations
+          if (awaitSync != null) {
+            try {
+              await awaitSync!();
+            } catch (e) {
+              _log.warning('Error waiting for sync: $e');
+            }
           }
-        } catch (e, stackTrace) {
-          // Ignore malformed custom messages
-          _log.warning(
-            'Error parsing custom message: $e',
-            e,
-            stackTrace,
-          );
+
+          try {
+            final payload = data.substring(_customPrefix.length);
+            final decoded = jsonDecode(payload);
+            if (decoded is Map<String, dynamic>) {
+              _customMessageController.add(decoded);
+            } else {
+              _log.warning('Custom message payload is not a Map: $decoded');
+            }
+          } catch (e, stackTrace) {
+            // Ignore malformed custom messages
+            _log.warning(
+              'Error parsing custom message: $e',
+              e,
+              stackTrace,
+            );
+          }
+        } else {
+          _inboundController.add(data);
         }
-      } else {
-        _inboundController.add(data);
-      }
+      });
     }, onError: (error, stackTrace) {
       _inboundController.addError(error, stackTrace);
       _customMessageController.addError(error, stackTrace);

--- a/decamp-app/lib/services/sync_service.dart
+++ b/decamp-app/lib/services/sync_service.dart
@@ -126,6 +126,7 @@ class SyncService {
       await db.customSelect('SELECT 1;').get();
 
       final crdt = db.crdt;
+      final adapter = CrdtFlowAdapter(crdt);
       // Remove trailing slash if present
       final cleanUrl = serverUrl.endsWith('/')
           ? serverUrl.substring(0, serverUrl.length - 1)
@@ -133,12 +134,15 @@ class SyncService {
       final uri = Uri.parse('$cleanUrl/sync/global');
 
       _log.info('Connecting to global sync at $uri');
-      _globalChannel = MultiplexedWebSocketChannel(_connectWebSocket(uri));
+      _globalChannel = MultiplexedWebSocketChannel(
+        _connectWebSocket(uri),
+        awaitSync: () => adapter.onIdle,
+      );
       _globalSubscription = _globalChannel!.onCustomMessage.listen((msg) {
         _log.fine('Global sync received custom message: $msg');
       });
       _globalSync = CrdtSync.client(
-        crdt,
+        adapter,
         _globalChannel!,
         verbose: true,
         validateRecord: (table, record) {
@@ -156,7 +160,7 @@ class SyncService {
               onlyNodeId,
               onlyTables,
             }) async {
-              final changeset = await crdt.getChangeset(
+              final changeset = await adapter.getChangeset(
                 onlyTables: onlyTables,
                 onlyNodeId: onlyNodeId,
                 exceptNodeId: exceptNodeId,
@@ -221,6 +225,7 @@ class SyncService {
       }
 
       final crdt = db.crdt;
+      final adapter = CrdtFlowAdapter(crdt);
       final uri = Uri.parse('$serverUrl/sync/project/$projectId');
 
       _log.info('Connecting to project sync at $uri');
@@ -253,14 +258,17 @@ class SyncService {
         return;
       }
 
-      _projectChannel = MultiplexedWebSocketChannel(monitoredChannel);
+      _projectChannel = MultiplexedWebSocketChannel(
+        monitoredChannel,
+        awaitSync: () => adapter.onIdle,
+      );
       _projectSubscription = _projectChannel!.onCustomMessage.listen((msg) {
         _log.fine('Project sync received custom message: $msg');
         if (msg['type'] == 'PONG') {
           _log.fine('PONG received: ${msg['payload']}');
         }
       });
-      _projectSync = CrdtSync.client(crdt, _projectChannel!, verbose: true);
+      _projectSync = CrdtSync.client(adapter, _projectChannel!, verbose: true);
     } catch (e) {
       if (token.isCancelled) return;
       _log.warning('Project DB not ready or error: $e');


### PR DESCRIPTION
Problem:

Although our multiplexing websocket channel guarantees order of messages, the CRDT Sqlite processes them asynchronously. As a result, race conditions may arise if a custom message arrives close to a CRDT message and performs database operations on the same resources. This PR introduces a synchronization mechanism that waits until merge operations complete before processing custom messages