### PR TITLE
Tool execution result store

### DIFF
--- a/agent-core/lib/src/agent_loop.dart
+++ b/agent-core/lib/src/agent_loop.dart
@@ -48,7 +48,7 @@ Future<AgentLoopResult> runAgentLoop({
   required ToolExecutionFunction executeToolCall,
   TextDeltaCallback? onTextDelta,
   MessageCallback? onAssistantMessage,
-  MessageCallback? onToolResultMessage,
+  ToolResultMessageCallback? onToolResultMessage,
 }) async {
   // Work with a mutable copy if using in-memory conversation
   var messages = conversation != null
@@ -162,7 +162,8 @@ Future<AgentLoopResult> runAgentLoop({
     // Add to in-memory conversation (will be overwritten if using getConversation)
     messages.add(toolResultMessage);
     if (onToolResultMessage != null) {
-      await onToolResultMessage(toolResultMessage);
+      await onToolResultMessage(toolResultMessage,
+          toolCallMessage: assistantMessage);
     }
 
     // Loop continues with updated conversation

--- a/agent-core/lib/src/controllers/chat_controller.dart
+++ b/agent-core/lib/src/controllers/chat_controller.dart
@@ -312,12 +312,16 @@ class ChatController extends StateNotifier<ChatState> {
       }
 
       Future<void> handleToolResultMessage(ChatMessage message,
-          {String? messageId}) async {
+          {String? messageId, ChatMessage? toolCallMessage}) async {
         // Use the ID provided by server, or generate one if local
         final idToUse = messageId ?? _messageDao.generateMessageId();
 
         await _messageDao.insertMessage(
-          message.toMessageCompanion(sessionId: sessionId, id: idToUse),
+          message.toMessageCompanion(
+            sessionId: sessionId,
+            id: idToUse,
+            toolCallMessage: toolCallMessage,
+          ),
         );
 
         await _sessionDao.touchSession(sessionId);

--- a/agent-core/lib/src/database/project_database.dart
+++ b/agent-core/lib/src/database/project_database.dart
@@ -220,12 +220,133 @@ class ProjectDatabase extends _$ProjectDatabase {
     if (row == null) return false;
     final currentSql = row.read<String>('sql');
 
+    // 1. Check if all code constraints are present in SQL (Added/Modified)
     for (final constraint in table.customConstraints) {
       if (!currentSql.contains(constraint)) {
         return true;
       }
     }
+
+    // 2. Check if there are any extra constraints in SQL (Removed)
+    final definitions = _parseTableDefinitions(currentSql);
+    final dbConstraints = definitions.where(_isConstraint).toList();
+
+    for (final dbConstraint in dbConstraints) {
+      bool matched = false;
+      for (final codeConstraint in table.customConstraints) {
+        if (dbConstraint.contains(codeConstraint)) {
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched &&
+          dbConstraint.trim().toUpperCase().startsWith('PRIMARY KEY')) {
+        if (_matchesPrimaryKey(dbConstraint, table)) {
+          matched = true;
+        }
+      }
+
+      if (!matched) {
+        return true;
+      }
+    }
+
     return false;
+  }
+
+  bool _matchesPrimaryKey(String dbConstraint, TableInfo table) {
+    if (table.primaryKey.isEmpty) return false;
+
+    final start = dbConstraint.indexOf('(');
+    final end = dbConstraint.lastIndexOf(')');
+    if (start == -1 || end == -1) return false;
+
+    final content = dbConstraint.substring(start + 1, end);
+    final dbCols = content.split(',').map((c) {
+      return c
+          .trim()
+          .replaceAll('"', '')
+          .replaceAll("'", '')
+          .replaceAll('`', '');
+    }).toList();
+
+    final tableCols = table.primaryKey.map((c) => c.name).toList();
+
+    if (dbCols.length != tableCols.length) return false;
+
+    for (int i = 0; i < dbCols.length; i++) {
+      if (dbCols[i] != tableCols[i]) return false;
+    }
+
+    return true;
+  }
+
+  List<String> _parseTableDefinitions(String sql) {
+    final startIndex = sql.indexOf('(');
+    if (startIndex == -1) return [];
+
+    int balance = 0;
+    int endIndex = -1;
+    for (int i = startIndex; i < sql.length; i++) {
+      if (sql[i] == '(') {
+        balance++;
+      } else if (sql[i] == ')') {
+        balance--;
+        if (balance == 0) {
+          endIndex = i;
+          break;
+        }
+      }
+    }
+
+    if (endIndex == -1) return [];
+
+    final content = sql.substring(startIndex + 1, endIndex);
+    final definitions = <String>[];
+    int currentStart = 0;
+    int parenBalance = 0;
+    bool inQuote = false;
+    String? quoteChar;
+
+    for (int i = 0; i < content.length; i++) {
+      final char = content[i];
+
+      if (inQuote) {
+        if (char == quoteChar) {
+          if (i + 1 < content.length && content[i + 1] == quoteChar) {
+            i++;
+          } else {
+            inQuote = false;
+            quoteChar = null;
+          }
+        }
+      } else {
+        if (char == '"' || char == "'" || char == '`') {
+          inQuote = true;
+          quoteChar = char;
+        } else if (char == '(') {
+          parenBalance++;
+        } else if (char == ')') {
+          parenBalance--;
+        } else if (char == ',' && parenBalance == 0) {
+          definitions.add(content.substring(currentStart, i).trim());
+          currentStart = i + 1;
+        }
+      }
+    }
+    definitions.add(content.substring(currentStart).trim());
+
+    return definitions.where((s) => s.isNotEmpty).toList();
+  }
+
+  bool _isConstraint(String def) {
+    final upper = def.toUpperCase();
+    return upper.startsWith('CONSTRAINT') ||
+        upper.startsWith('PRIMARY KEY') ||
+        upper.startsWith('FOREIGN KEY') ||
+        upper.startsWith('CHECK') ||
+        upper.startsWith('UNIQUE');
   }
 
   Future<void> _recreateTable(Migrator m, TableInfo table) async {

--- a/agent-core/lib/src/database/project_database.dart
+++ b/agent-core/lib/src/database/project_database.dart
@@ -235,44 +235,59 @@ class ProjectDatabase extends _$ProjectDatabase {
     // 1. Rename existing table
     await executor.runCustom('ALTER TABLE $tableName RENAME TO $tempName');
 
-    // 2. Create new table
-    await m.createTable(table);
+    try {
+      // 2. Create new table
+      await m.createTable(table);
 
-    // 3. Restore extra columns (CRDT columns etc)
-    final oldColumnsInfo = await _getExistingColumnsInfo(tempName);
-    final newColumns = table.$columns.map((c) => c.name).toSet();
-    final currentNewColumns = await _getExistingColumns(tableName);
+      // 3. Restore extra columns (CRDT columns etc)
+      final oldColumnsInfo = await _getExistingColumnsInfo(tempName);
+      final newColumns = table.$columns.map((c) => c.name).toSet();
+      final currentNewColumns = await _getExistingColumns(tableName);
 
-    final extraColumns = oldColumnsInfo.where((c) =>
-        !newColumns.contains(c.name) &&
-        c.name != 'is_starred' && // Explicitly drop is_starred
-        !currentNewColumns.contains(c.name));
+      final extraColumns = oldColumnsInfo.where((c) =>
+          !newColumns.contains(c.name) &&
+          c.name != 'is_starred' && // Explicitly drop is_starred
+          !currentNewColumns.contains(c.name));
 
-    for (final col in extraColumns) {
-      _log.info('Restoring extra column ${col.name} to $tableName');
-      var sql = 'ALTER TABLE $tableName ADD COLUMN ${col.name} ${col.type}';
-      if (col.notNull == 1 && col.dfltValue != null) {
-        sql += ' DEFAULT ${col.dfltValue}';
-      } else if (col.notNull == 1) {
-        sql += ' NOT NULL';
+      for (final col in extraColumns) {
+        _log.info('Restoring extra column ${col.name} to $tableName');
+        var sql = 'ALTER TABLE $tableName ADD COLUMN ${col.name} ${col.type}';
+        if (col.notNull == 1 && col.dfltValue != null) {
+          sql += ' DEFAULT ${col.dfltValue}';
+        } else if (col.notNull == 1) {
+          sql += ' NOT NULL';
+        }
+        await executor.runCustom(sql);
       }
-      await executor.runCustom(sql);
+
+      // 4. Copy data
+      final currentColumns =
+          await _getExistingColumns(tableName); // Should be new + extra
+      final oldColumnNames = oldColumnsInfo.map((c) => c.name).toSet();
+      final commonColumns = currentColumns.intersection(oldColumnNames);
+
+      if (commonColumns.isNotEmpty) {
+        final cols = commonColumns.join(', ');
+        await executor.runCustom(
+            'INSERT INTO $tableName ($cols) SELECT $cols FROM $tempName');
+      }
+
+      // 5. Drop old table
+      await executor.runCustom('DROP TABLE $tempName');
+    } catch (e, s) {
+      _log.severe(
+          'Failed to recreate table $tableName, attempting rollback', e, s);
+      try {
+        // Drop the new table if it exists
+        await executor.runCustom('DROP TABLE IF EXISTS $tableName');
+        // Restore the old table
+        await executor.runCustom('ALTER TABLE $tempName RENAME TO $tableName');
+        _log.info('Rollback successful for $tableName');
+      } catch (e2, s2) {
+        _log.severe('Rollback failed for $tableName', e2, s2);
+      }
+      rethrow;
     }
-
-    // 4. Copy data
-    final currentColumns =
-        await _getExistingColumns(tableName); // Should be new + extra
-    final oldColumnNames = oldColumnsInfo.map((c) => c.name).toSet();
-    final commonColumns = currentColumns.intersection(oldColumnNames);
-
-    if (commonColumns.isNotEmpty) {
-      final cols = commonColumns.join(', ');
-      await executor.runCustom(
-          'INSERT INTO $tableName ($cols) SELECT $cols FROM $tempName');
-    }
-
-    // 5. Drop old table
-    await executor.runCustom('DROP TABLE $tempName');
 
     // 6. Canonicalize CRDT to restore triggers
     try {

--- a/agent-core/lib/src/database/project_database.dart
+++ b/agent-core/lib/src/database/project_database.dart
@@ -121,7 +121,14 @@ class ProjectDatabase extends _$ProjectDatabase {
       if (!existingTables.contains(table.actualTableName)) {
         await m.createTable(table);
       } else {
-        await _reconcileTable(m, table);
+        final constraintsChanged = await _checkConstraintsChanged(table);
+        if (constraintsChanged) {
+          _log.info(
+              'Recreating table ${table.actualTableName} due to constraint changes');
+          await _recreateTable(m, table);
+        } else {
+          await _reconcileTable(m, table);
+        }
       }
     }
 
@@ -203,4 +210,112 @@ class ProjectDatabase extends _$ProjectDatabase {
       'CREATE INDEX IF NOT EXISTS saved_prompts_project_last_used_idx ON saved_prompts (project_id, last_used_at DESC, created_at DESC)',
     );
   }
+
+  Future<bool> _checkConstraintsChanged(TableInfo table) async {
+    final row = await customSelect(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='${table.actualTableName}'",
+      readsFrom: {},
+    ).getSingleOrNull();
+
+    if (row == null) return false;
+    final currentSql = row.read<String>('sql');
+
+    for (final constraint in table.customConstraints) {
+      if (!currentSql.contains(constraint)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Future<void> _recreateTable(Migrator m, TableInfo table) async {
+    final tableName = table.actualTableName;
+    final tempName = '${tableName}_backup';
+
+    // 1. Rename existing table
+    await executor.runCustom('ALTER TABLE $tableName RENAME TO $tempName');
+
+    // 2. Create new table
+    await m.createTable(table);
+
+    // 3. Restore extra columns (CRDT columns etc)
+    final oldColumnsInfo = await _getExistingColumnsInfo(tempName);
+    final newColumns = table.$columns.map((c) => c.name).toSet();
+    final currentNewColumns = await _getExistingColumns(tableName);
+
+    final extraColumns = oldColumnsInfo.where((c) =>
+        !newColumns.contains(c.name) &&
+        c.name != 'is_starred' && // Explicitly drop is_starred
+        !currentNewColumns.contains(c.name));
+
+    for (final col in extraColumns) {
+      _log.info('Restoring extra column ${col.name} to $tableName');
+      var sql = 'ALTER TABLE $tableName ADD COLUMN ${col.name} ${col.type}';
+      if (col.notNull == 1 && col.dfltValue != null) {
+        sql += ' DEFAULT ${col.dfltValue}';
+      } else if (col.notNull == 1) {
+        sql += ' NOT NULL';
+      }
+      await executor.runCustom(sql);
+    }
+
+    // 4. Copy data
+    final currentColumns =
+        await _getExistingColumns(tableName); // Should be new + extra
+    final oldColumnNames = oldColumnsInfo.map((c) => c.name).toSet();
+    final commonColumns = currentColumns.intersection(oldColumnNames);
+
+    if (commonColumns.isNotEmpty) {
+      final cols = commonColumns.join(', ');
+      await executor.runCustom(
+          'INSERT INTO $tableName ($cols) SELECT $cols FROM $tempName');
+    }
+
+    // 5. Drop old table
+    await executor.runCustom('DROP TABLE $tempName');
+
+    // 6. Canonicalize CRDT to restore triggers
+    try {
+      final c = _crdt ?? (_crdtProvider != null ? _crdtProvider() : null);
+      if (c is SqliteCrdt) {
+        // Try to call canonicalize dynamically to restore triggers
+        await (c as dynamic).canonicalize();
+      }
+    } catch (e) {
+      _log.warning('Failed to canonicalize CRDT after table recreation', e);
+    }
+  }
+
+  Future<List<PragmaTableInfo>> _getExistingColumnsInfo(
+      String tableName) async {
+    final rows = await customSelect(
+      "SELECT * FROM pragma_table_info('$tableName')",
+      readsFrom: {},
+    ).get();
+    return rows
+        .map((row) => PragmaTableInfo(
+              name: row.read<String>('name'),
+              type: row.read<String>('type'),
+              notNull: row.read<int>('notnull'),
+              dfltValue: row.read<String?>('dflt_value'),
+              pk: row.read<int>('pk'),
+            ))
+        .toList();
+  }
+}
+
+class PragmaTableInfo {
+  final String name;
+  final String type;
+  final int notNull;
+  final String? dfltValue;
+  final int pk;
+
+  PragmaTableInfo({
+    required this.name,
+    required this.type,
+    required this.notNull,
+    this.dfltValue,
+    required this.pk,
+  });
 }

--- a/agent-core/lib/src/database/tables/messages_table.dart
+++ b/agent-core/lib/src/database/tables/messages_table.dart
@@ -66,7 +66,7 @@ class Messages extends Table {
             '(message_kind = 0 AND image_url IS NULL AND tool_calls_json IS NULL AND tool_results_json IS NULL) OR ' // text
             '(message_kind = 1 AND image_url IS NOT NULL AND tool_calls_json IS NULL AND tool_results_json IS NULL) OR ' // imageUrl
             '(message_kind = 2 AND image_url IS NULL AND tool_calls_json IS NOT NULL AND tool_results_json IS NULL) OR ' // toolUse
-            '(message_kind = 3 AND image_url IS NULL AND tool_calls_json IS NULL AND tool_results_json IS NOT NULL)' // toolResult
+            '(message_kind = 3 AND image_url IS NULL AND tool_results_json IS NOT NULL)' // toolResult
             ')',
       ];
 }

--- a/agent-core/lib/src/database/tables/messages_table.dart
+++ b/agent-core/lib/src/database/tables/messages_table.dart
@@ -61,12 +61,6 @@ class Messages extends Table {
 
   @override
   List<String> get customConstraints => [
-        // Ensure only the appropriate column is populated for each message kind
-        'CHECK ('
-            '(message_kind = 0 AND image_url IS NULL AND tool_calls_json IS NULL AND tool_results_json IS NULL) OR ' // text
-            '(message_kind = 1 AND image_url IS NOT NULL AND tool_calls_json IS NULL AND tool_results_json IS NULL) OR ' // imageUrl
-            '(message_kind = 2 AND image_url IS NULL AND tool_calls_json IS NOT NULL AND tool_results_json IS NULL) OR ' // toolUse
-            '(message_kind = 3 AND image_url IS NULL AND tool_results_json IS NOT NULL)' // toolResult
-            ')',
+        // WARNING: DO NOT ADD CONSTRAINTS, as they may cause issues with CRDT merges
       ];
 }

--- a/agent-core/lib/src/extensions/chat_message_extensions.dart
+++ b/agent-core/lib/src/extensions/chat_message_extensions.dart
@@ -12,6 +12,7 @@ extension ChatMessageToDB on ChatMessage {
     required String sessionId,
     String? id,
     String? userName,
+    ChatMessage? toolCallMessage,
   }) {
     final now = DateTime.now();
     final messageId = id ?? IdGenerator.messageId();
@@ -44,7 +45,10 @@ extension ChatMessageToDB on ChatMessage {
       case ToolResultMessage(:final results):
         kind = MessageKind.toolResult;
         imageUrlValue = null;
-        toolCallsValue = null;
+        toolCallsValue = switch (toolCallMessage?.messageType) {
+          ToolUseMessage(:final toolCalls) => toolCalls,
+          _ => null,
+        };
         toolResultsValue = results;
 
       default:

--- a/agent-core/lib/src/types.dart
+++ b/agent-core/lib/src/types.dart
@@ -54,6 +54,11 @@ typedef TextDeltaCallback = void Function(String delta);
 typedef MessageCallback = Future<void> Function(ChatMessage message,
     {String? messageId});
 
+typedef ToolResultMessageCallback = Future<void> Function(
+    ChatMessage toolResultMessage,
+    {String? messageId,
+    ChatMessage? toolCallMessage});
+
 /// Optional callback to get fresh conversation (e.g., from database)
 /// If provided, called at the start of each iteration instead of using in-memory list
 typedef ConversationProvider = Future<List<ChatMessage>> Function();

--- a/agent-core/lib/src/utils/tool_result_formatter.dart
+++ b/agent-core/lib/src/utils/tool_result_formatter.dart
@@ -143,7 +143,12 @@ class ToolResultFormatter {
   }
 
   /// Format a tool result based on the tool name
-  static String format({required String toolName, required String result}) {
+  static String format({
+    required String toolName,
+    required String result,
+    List<ToolCall>? originalToolCalls,
+    String? toolCallId,
+  }) {
     // Parse the result JSON
     Map<String, dynamic>? data;
     try {
@@ -155,7 +160,8 @@ class ToolResultFormatter {
 
     // Route to specific formatter based on tool name
     return switch (toolName) {
-      kExecuteShellCommand => _formatShellCommand(data),
+      kExecuteShellCommand =>
+        _formatShellCommand(data, originalToolCalls, toolCallId),
       kFetch => _formatFetchResult(data),
       _ => _formatUnknownTool(toolName, result),
     };
@@ -169,7 +175,11 @@ class ToolResultFormatter {
   /// - Exit code (if non-zero or failed)
   /// - Standard output (if available)
   /// - Standard error (if available, labeled as warnings or errors based on success)
-  static String _formatShellCommand(Map<String, dynamic> data) {
+  static String _formatShellCommand(
+    Map<String, dynamic> data,
+    List<ToolCall>? originalToolCalls,
+    String? toolCallId,
+  ) {
     final buffer = StringBuffer();
 
     final exitCode = data['exitCode'] as int? ?? -1;
@@ -182,6 +192,26 @@ class ToolResultFormatter {
       buffer.writeln('✅ Command Executed Successfully:\n');
     } else {
       buffer.writeln('❌ **Command Failed**\n');
+    }
+
+    // Try to find original command
+    if (originalToolCalls != null && toolCallId != null) {
+      try {
+        final originalCall = originalToolCalls.firstWhere(
+          (tc) => tc.id == toolCallId,
+          orElse: () => throw Exception('Not found'),
+        );
+        final args =
+            jsonDecode(originalCall.function.arguments) as Map<String, dynamic>;
+        final command = args['command'] as String?;
+        if (command != null) {
+          buffer.writeln('```bash');
+          buffer.writeln(command);
+          buffer.writeln('```\n');
+        }
+      } catch (_) {
+        // Ignore if not found or parsing fails
+      }
     }
 
     // Exit code (show if not 0 or if command failed)

--- a/decamp-agent/lib/controllers/sync_controller.dart
+++ b/decamp-agent/lib/controllers/sync_controller.dart
@@ -416,12 +416,20 @@ class _AgentSession {
             }
             await db!.sessionDao.touchSession(currentSessionId);
           },
-          onToolResultMessage: (message, {String? messageId}) async {
+          onToolResultMessage: (
+            message, {
+            String? messageId,
+            ChatMessage? toolCallMessage,
+          }) async {
             String? id;
             // db and sessionId are guaranteed to be non-null here due to checks at start of method
             id = db!.messageDao.generateMessageId();
             await db!.messageDao.insertMessage(
-              message.toMessageCompanion(sessionId: currentSessionId, id: id),
+              message.toMessageCompanion(
+                sessionId: currentSessionId,
+                id: id,
+                toolCallMessage: toolCallMessage,
+              ),
             );
             await db!.sessionDao.touchSession(currentSessionId);
           },

--- a/decamp-app/lib/utils/message_formatter.dart
+++ b/decamp-app/lib/utils/message_formatter.dart
@@ -35,7 +35,12 @@ class MessageFormatter {
 
         // Format using the tool result formatter
         buffer.write(
-          ToolResultFormatter.format(toolName: toolName, result: resultContent),
+          ToolResultFormatter.format(
+            toolName: toolName,
+            result: resultContent,
+            originalToolCalls: message.toolCallsJson,
+            toolCallId: toolResult.id,
+          ),
         );
       }
 


### PR DESCRIPTION
-Changes the way tool results messages are stored - results also carry information about the original tool calls.
-Tool result messages for shell commands now display the original shell command that invoked it.
-Removes CHECK constraints from messages table (they were too rigid).
